### PR TITLE
Fix calendar print schedule handler initialization

### DIFF
--- a/src/components/calendar/SchedulingCalendar.tsx
+++ b/src/components/calendar/SchedulingCalendar.tsx
@@ -704,7 +704,11 @@ export const SchedulingCalendar = forwardRef<SchedulingCalendarHandle, Schedulin
       })
       .filter((event): event is CalendarEventSnapshot => event !== null);
   }, [getCalendarApi]);
-\r\n      if (!api) {
+
+  const printSchedule = useCallback(
+    (options: { viewName?: string; date?: Date } = {}) => {
+      const api = getCalendarApi();
+      if (!api) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- wrap the scheduling calendar print handler in a useCallback so the calendar API is accessed safely
- ensure the print handler restores the previous view and date and cleans up after printing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ac3dee0083248007a6eff6e95338