### PR TITLE
refine printable schedule layouts

### DIFF
--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -34,12 +34,6 @@ interface ScheduleReportSummary {
   events: CalendarEventSnapshot[];
 }
 
-const scheduleViewMap: Record<ReportScope, string> = {
-  day: 'resourceTimeGridDay',
-  week: 'resourceTimeGridWeek',
-  month: 'dayGridMonth',
-};
-
 const scopeLabels: Record<ReportScope, string> = {
   day: 'Day',
   week: 'Week',
@@ -241,8 +235,12 @@ export function CalendarPage() {
       return;
     }
 
-    const viewName = scheduleViewMap[scope];
-    calendar.printSchedule({ viewName });
+    const anchorDate = calendar.getCurrentDate();
+    calendar.printSchedule({
+      scope,
+      date: anchorDate,
+      title: 'Mechanic Shop OS – Service Schedule',
+    });
   };
 
 


### PR DESCRIPTION
## Summary
- streamline week and month printable schedule PDFs into aggregated tables with scoped columns and day headers
- keep the detailed day view while sharing table rendering helpers across layouts and adding matching styles
- ensure printable schedule day grouping uses timezone-stable keys so empty days render reliably

## Testing
- not run (per user request)


------
https://chatgpt.com/codex/tasks/task_e_68d1b87cee3c8324a1438211c76dcbb4