### PR TITLE
Fix selection history updates

### DIFF
--- a/src/stores/__tests__/selection-store.test.ts
+++ b/src/stores/__tests__/selection-store.test.ts
@@ -51,6 +51,24 @@ describe('selection store dock transitions', () => {
       entityId: 'job-123',
       initialData: { title: 'Test Entity' },
     });
+    expect(state.history.items).toHaveLength(1);
+    expect(state.history.items[0]?.id).toBe('job-123');
+    expect(state.recentItems).toHaveLength(1);
+    expect(state.recentItems[0]?.id).toBe('job-123');
+  });
+
+  it('does not duplicate history or recent entries for the same selection', () => {
+    const { selectItem } = useSelectionStore.getState();
+
+    const firstSelection = buildSelection({ id: 'job-123', type: 'job' });
+    selectItem(firstSelection);
+    selectItem(firstSelection);
+    selectItem(buildSelection({ id: 'job-456', type: 'job' }));
+
+    const state = useSelectionStore.getState();
+
+    expect(state.history.items.map((item) => item.id)).toEqual(['job-456', 'job-123']);
+    expect(state.recentItems.map((item) => item.id)).toEqual(['job-456', 'job-123']);
   });
 
   it('showMenu switches the dock back to menu view without closing it', () => {


### PR DESCRIPTION
## Summary
- ensure selecting an item updates history and recent lists in the selection store
- refactor history/recent helpers to avoid nested zustand updates and reuse for store actions
- expand selection store tests to assert history and recent tracking behaviour

## Testing
- npm test -- --run
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d49b4ca99083249f2273df82d687c5